### PR TITLE
Start of unittesting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,5 @@
 *.egg-info
+__pycache__
+.coverage
+*.pyc
+*.pyo

--- a/pykube/config.py
+++ b/pykube/config.py
@@ -5,8 +5,11 @@ Configuration code.
 import base64
 import copy
 import tempfile
+import os
 
 import yaml
+
+from pykube import exceptions
 
 
 class KubeConfig(object):
@@ -21,6 +24,9 @@ class KubeConfig(object):
         :Parameters:
            - `filename`: The full path to the configuration file
         """
+        if not os.path.isfile(filename):
+            raise exceptions.PyKubeError(
+                "Configuration file {} not found".format(filename))
         self.filename = filename
         self.doc = None
         self.current_context = None
@@ -98,7 +104,7 @@ class KubeConfig(object):
         """
         self.parse()
         if self.current_context is None:
-            raise Exception("current context not set; call set_current_context")
+            raise exceptions.PyKubeError("current context not set; call set_current_context")
         return self.clusters[self.contexts[self.current_context]["cluster"]]
 
     @property
@@ -108,7 +114,7 @@ class KubeConfig(object):
         """
         self.parse()
         if self.current_context is None:
-            raise Exception("current context not set; call set_current_context")
+            raise exceptions.PyKubeError("current context not set; call set_current_context")
         return self.users[self.contexts[self.current_context]["user"]]
 
 

--- a/pykube/exceptions.py
+++ b/pykube/exceptions.py
@@ -8,3 +8,10 @@ class KubernetesError(Exception):
     Base exception for all Kubernetes errors.
     """
     pass
+
+
+class PyKubeError(KubernetesError):
+    """
+    PyKube specific errors.
+    """
+    pass

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -1,0 +1,12 @@
+"""
+Unittests
+"""
+
+import unittest
+
+
+class TestCase(unittest.TestCase):
+    """
+    Parent class for all unittests.
+    """
+    pass

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -1,0 +1,103 @@
+"""
+pykube.config unittests
+"""
+
+import os
+
+from pykube import config, exceptions
+
+from . import TestCase
+
+
+GOOD_CONFIG_FILE_PATH = os.path.sep.join(["test", "test_config.yaml"])
+
+
+class TestConfig(TestCase):
+
+    def setUp(self):
+        self.cfg = config.KubeConfig(GOOD_CONFIG_FILE_PATH)
+
+    def tearDown(self):
+        self.cfg = None
+
+    def test_init(self):
+        """
+        Test Config instance creation.
+        """
+        # Ensure that a valid creation works
+        self.assertEqual(
+            GOOD_CONFIG_FILE_PATH,
+            self.cfg.filename)
+
+        # Ensure that if a file does not exist the creation fails
+        self.assertRaises(
+            exceptions.PyKubeError,
+            config.KubeConfig,
+            "doesnotexist")
+
+    def test_set_current_context(self):
+        """
+        Verify set_current_context works as expected.
+        """
+        self.cfg.set_current_context("new_context")
+        self.assertEqual(
+            "new_context",
+            self.cfg.current_context)
+
+    def test_clusters(self):
+        """
+        Verify clusters works as expected.
+        """
+        self.assertEqual(
+            {"server": "http://localhost"},
+            self.cfg.clusters.get("thecluster", None))
+
+    def test_users(self):
+        """
+        Verify users works as expected.
+        """
+        self.assertEqual(
+            "data",
+            self.cfg.users.get("admin", None))
+
+    def test_contexts(self):
+        """
+        Verify contexts works as expected.
+        """
+        self.assertEqual(
+            {"cluster": "thecluster", "user": "admin"},
+            self.cfg.contexts.get("thename", None))
+
+    def test_cluster(self):
+        """
+        Verify cluster works as expected.
+        """
+        # Without a current_context this should fail
+        try:
+            cluster = self.cfg.cluster
+            self.fail(
+                "cluster was found without a current context set: {}".format(
+                    cluster))
+        except exceptions.PyKubeError:
+            # We should get an error
+            pass
+
+        self.cfg.set_current_context("thename")
+        self.assertEqual({"server": "http://localhost"}, self.cfg.cluster)
+
+    def test_user(self):
+        """
+        Verify user works as expected.
+        """
+        # Without a current_context this should fail
+        try:
+            user = self.cfg.user
+            self.fail(
+                "user was found without a current context set: {}".format(
+                    user))
+        except exceptions.PyKubeError:
+            # We should get an error
+            pass
+
+        self.cfg.set_current_context("thename")
+        self.assertEqual("data", self.cfg.user)

--- a/test/test_config.yaml
+++ b/test/test_config.yaml
@@ -1,0 +1,14 @@
+# TODO: Replace with a more realistic example
+clusters:
+    - name: thecluster
+      cluster: {}
+users:
+    - name: admin
+      user: data
+contexts:
+    - name: thename
+      context:
+        cluster: thecluster
+        user: admin
+    - name: second
+      context: secondcontext


### PR DESCRIPTION
This PR adds the start of unittesting and is compatible with both Python 2.7 and 3.x. It also includes updates to ```.gitignore``` for python and test related files.

```
$ nosetests -v --with-coverage --cover-package=pykube test/
Verify cluster works as expected. ... ok
Verify clusters works as expected. ... ok
Verify contexts works as expected. ... ok
Test Config instance creation. ... ok
Verify set_current_context works as expected. ... ok
Verify user works as expected. ... ok
Verify users works as expected. ... ok

Name                Stmts   Miss  Cover   Missing
-------------------------------------------------
pykube                  0      0   100%
pykube.config          87     15    83%   134, 143-148, 154-158, 164-169
pykube.exceptions       4      0   100%
-------------------------------------------------
TOTAL                  91     15    84%
----------------------------------------------------------------------
Ran 7 tests in 0.028s

OK
```