### PR TITLE
Added setup.cfg for pep8 configuration

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,4 @@
+; See https://pep8.readthedocs.org/en/latest/intro.html#configuration
+[pep8]
+; E501=line too long (82 > 79 characters)
+ignore=E501


### PR DESCRIPTION
```pep8``` will ignore ```E501``` which is "line too long (82 > 79 characters)". Other exceptions can be listed in ignore per https://pep8.readthedocs.org/en/latest/intro.html#configuration.

Related to #2 