### PR TITLE
Allow namespace argument for `BaseQuery.all()`

### DIFF
--- a/pykube/query.py
+++ b/pykube/query.py
@@ -20,8 +20,14 @@ class BaseQuery(object):
         self.namespace = namespace
         self.selector = everything
 
-    def all(self):
-        return self._clone()
+    def all(self, namespace=None):
+        """
+        Return a BaseQuery instance without selector.
+
+        :Parameters:
+            - `namespace`: Optional namespace (string or pykube.all)
+        """
+        return self.filter(namespace=namespace, selector=None)
 
     def filter(self, namespace=None, selector=None):
         clone = self._clone()


### PR DESCRIPTION
This adds a optional `namespace` parameter to `BaseQuery.all()`.
That would allow to query all objects in a namespace (or all namespaces) without utilizing `.filter(namespace=...)`:
```py
pykube.Service.objects(api).all(namespace=pykube.all)
```

instead of
```py
pykube.Service.objects(api).filter(namespace=pykube.all)
```