### PR TITLE
Improving rolling updater and fixing logging

### DIFF
--- a/pykube/rolling_updater.py
+++ b/pykube/rolling_updater.py
@@ -6,7 +6,6 @@ from .objects import Pod
 from .exceptions import KubernetesError
 
 
-logging.basicConfig(format='%(levelname)s:%(message)s', level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 


### PR DESCRIPTION
This pull requests fixes the logging system that was not printing anything if you use pykube standalone without any preivous logging configuration.

Improves the rolling update update method by doing the same checks as kubectl like:
- The selector in the new rc needs to be different than the old rc
- The selector in the new rc needs to be the same as the template labels in the new rc

Without these checks, pykube was getting just a non descriptive HTTP error.

The exception messages are copied from kubectl messages when the error occurs.

I also added info messages when creating and cleaning up rcs simulating what kubectl is doing.