### PR TITLE
Adding kind attribute to objects

### DIFF
--- a/pykube/objects.py
+++ b/pykube/objects.py
@@ -111,54 +111,63 @@ class ConfigMap(NamespacedAPIObject):
 
     version = "v1"
     endpoint = "configmaps"
+    kind = "ConfigMap"
 
 
 class DaemonSet(NamespacedAPIObject):
 
     version = "extensions/v1beta1"
     endpoint = "daemonsets"
+    kind = "DaemonSet"
 
 
 class Deployment(NamespacedAPIObject, ReplicatedAPIObject):
 
     version = "extensions/v1beta1"
     endpoint = "deployments"
+    kind = "Deployment"
 
 
 class Endpoint(NamespacedAPIObject):
 
     version = "v1"
     endpoint = "endpoints"
+    kind = "Endpoint"
 
 
 class Ingress(NamespacedAPIObject):
 
     version = "extensions/v1beta1"
     endpoint = "ingresses"
+    kind = "Ingress"
 
 
 class Job(NamespacedAPIObject):
 
     version = "extensions/v1beta1"
     endpoint = "jobs"
+    kind = "Job"
 
 
 class Namespace(APIObject):
 
     version = "v1"
     endpoint = "namespaces"
+    kind = "Namespace"
 
 
 class Node(APIObject):
 
     version = "v1"
     endpoint = "nodes"
+    kind = "Node"
 
 
 class Pod(NamespacedAPIObject):
 
     version = "v1"
     endpoint = "pods"
+    kind = "Pod"
 
     @property
     def ready(self):
@@ -171,6 +180,7 @@ class ReplicationController(NamespacedAPIObject, ReplicatedAPIObject):
 
     version = "v1"
     endpoint = "replicationcontrollers"
+    kind = "ReplicationController"
 
     def scale(self, replicas=None):
         if replicas is None:
@@ -189,21 +199,25 @@ class Secret(NamespacedAPIObject):
 
     version = "v1"
     endpoint = "secrets"
+    kind = "Secret"
 
 
 class Service(NamespacedAPIObject):
 
     version = "v1"
     endpoint = "services"
+    kind = "Secret"
 
 
 class PersistentVolume(APIObject):
 
     version = "v1"
     endpoint = "persistentvolumes"
+    kind = "PersistentVolume"
 
 
 class PersistentVolumeClaim(NamespacedAPIObject):
 
     version = "v1"
     endpoint = "persistentvolumeclaims"
+    kind = "PersistentVolumeClaim"

--- a/pykube/objects.py
+++ b/pykube/objects.py
@@ -206,7 +206,7 @@ class Service(NamespacedAPIObject):
 
     version = "v1"
     endpoint = "services"
-    kind = "Secret"
+    kind = "Service"
 
 
 class PersistentVolume(APIObject):


### PR DESCRIPTION
From the api you can retrieve the objects and their data is stored in .obj as a dict. That dict doesn't have all the elements, the 'kind' and 'apiVersion' items are missing. In pykube luckily we have the version because it belongs to the object class, but there is no way to get the 'kind' item.

Example, this is the obj dict retrieved from kubernetes through the api:

```python
{u'metadata': 
  {u'annotations': 
    {u'commit': u'00176a9748726369fa23f1d63ad962194d398101',
     u'gitrepo': u'configserver',
     u'kubereye-managed': u'true'},
  u'creationTimestamp': u'2016-03-04T07:13:21Z',
  u'name': u'configserver',
  u'namespace': u'main',
  u'resourceVersion': u'2558676',
  u'selfLink': u'/api/v1/namespaces/main/services/configserver',
  u'uid': u'9418d01d-e1d8-11e5-bf0d-44a8424811b9'},
 u'spec': {u'clusterIP': u'10.3.0.224',
  u'ports': [{u'nodePort': 32600,
    u'port': 8080,
    u'protocol': u'TCP',
    u'targetPort': 8080}],
  u'selector': {u'app': u'configserver', u'tier': u'common'},
  u'sessionAffinity': u'None',
  u'type': u'NodePort'},
 u'status': {u'loadBalancer': {}}}
```

And this is the json output gotten with:
```
kubectl get service configserver -o json
```

```json
{
    "kind": "Service",
    "apiVersion": "v1",
    "metadata": {
        "name": "configserver",
        "namespace": "main",
        "selfLink": "/api/v1/namespaces/main/services/configserver",
        "uid": "9418d01d-e1d8-11e5-bf0d-44a8424811b9",
        "resourceVersion": "2558676",
        "creationTimestamp": "2016-03-04T07:13:21Z",
        "annotations": {
            "commit": "00176a9748726369fa23f1d63ad962194d398101",
            "gitrepo": "configserver",
            "kubereye-managed": "true"
        }
    },
    "spec": {
        "ports": [
            {
                "protocol": "TCP",
                "port": 8080,
                "targetPort": 8080,
                "nodePort": 32600
            }
        ],
        "selector": {
            "app": "configserver",
            "tier": "common"
        },
        "clusterIP": "10.3.0.224",
        "type": "NodePort",
        "sessionAffinity": "None"
    },
    "status": {
        "loadBalancer": {}
    }
}
```

With this pull request you have the 'kind' item as an attribute, and it is something tied to the class, like the version.
This is useful if you have a resource and want to infer its type to, for example, compare with others from the same type.